### PR TITLE
[ENH] update index with shorthand index if only one entry

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,4 +46,3 @@ Installation
    config
    contribute
    issues
-

--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -793,17 +793,23 @@ class MystTranslator(SphinxTranslator):
 
     def parse_index_as_directive(self, node):
         self.index["type"] = "directive"
-        syntax = []
-        syntax.append(self.syntax.visit_directive("index"))
+        entries = []
         options = []
         for entry in node.attributes["entries"]:
             entrytype, entryname, target, ignored, key = entry
-            syntax.append("{}: {}".format(entrytype, entryname))
+            entries.append("{}: {}".format(entrytype, entryname))
             # Sphinx > 3.0
             if not re.match("index-", target) and target != "":
                 option = ":name: {}".format(target)
                 if option not in options:
                     options.append(option)
+        # -Construct Syntax
+        syntax = []
+        if len(entries) == 1:
+            syntax.append(self.syntax.visit_directive("index", argument=entries[0]))
+        else:
+            syntax.append(self.syntax.visit_directive("index"))
+            syntax += entries
         syntax += options
         syntax.append(self.syntax.depart_directive())
         return "\n".join(syntax)

--- a/tests/source/sphinx/directives.rst
+++ b/tests/source/sphinx/directives.rst
@@ -1,6 +1,27 @@
 Directives
 ==========
 
+index
+-----
+
+The index directives
+
+.. index::
+   single: Python
+
+.. index::
+   single: Python
+   :name: test1
+
+.. index::
+   single: Python; Runtime
+   single: Julia
+
+.. index::
+   single: Python; Runtime
+   single: Julia
+   :name: test2
+
 only
 ----
 

--- a/tests/test_mystparser/test_docutils.myst
+++ b/tests/test_mystparser/test_docutils.myst
@@ -219,8 +219,7 @@ This is a highlights directive
 
 ## index
 
-```{index}
-single: python
+```{index} single: python
 ```
 
 ```{index}
@@ -241,8 +240,7 @@ single: programming
 A point in the text you'd like to reference something
 about python
 
-```{index}
-single: execution; context
+```{index} single: execution; context
 ```
 
 ## The execution context

--- a/tests/test_mystparser/test_sphinx.myst
+++ b/tests/test_mystparser/test_sphinx.myst
@@ -42,6 +42,30 @@ kernelspec:
 
 # Directives
 
+## index
+
+The index directives
+
+```{index} single: Python
+```
+
+```{index} single: Python
+:name: test1
+```
+
+(test1)=
+```{index}
+single: Python; Runtime
+single: Julia
+```
+
+```{index}
+single: Python; Runtime
+single: Julia
+:name: test2
+```
+
+(test2)=
 ## only
 
 The only directive

--- a/tests/test_mystparser/test_sphinx.xml
+++ b/tests/test_mystparser/test_sphinx.xml
@@ -2,7 +2,20 @@
     <section ids="directives" names="directives">
         <title>
             Directives
-        <section ids="only" names="only">
+        <section ids="index" names="index">
+            <title>
+                index
+            <paragraph>
+                The index directives
+            <index entries="('single',\ 'Python',\ 'index-0',\ '',\ None)" inline="False">
+            <target ids="index-0">
+            <index entries="('single',\ 'Python',\ 'test1',\ '',\ None)" inline="False">
+            <target ids="test1" names="test1">
+            <index entries="('single',\ 'Python;\ Runtime',\ 'index-1',\ '',\ None) ('single',\ 'Julia',\ 'index-1',\ '',\ None)" inline="False">
+            <target ids="index-1">
+            <index entries="('single',\ 'Python;\ Runtime',\ 'test2',\ '',\ None) ('single',\ 'Julia',\ 'test2',\ '',\ None)" inline="False">
+            <target refid="test2">
+        <section ids="only test2" names="only test2">
             <title>
                 only
             <paragraph>


### PR DESCRIPTION
This improves compatibility with current `myst` parser. If a single `index` entry is used in `rst` then it will return the option on the top line of the directive. 

```rst
.. index::
   single: Python
```

will become:

````
```{index} single: Python
```
````

while multioption `index` elements 

```rst
.. index::
   single: Python; Runtime
   single: Julia
```

will still be included as (which is [currently unsupported](https://github.com/executablebooks/meta/discussions/155)):


````
```{index}
single: Python; Runtime
single: Julia
```
````


