### PR TITLE
[ENH] add support for parsing of index roles

### DIFF
--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -800,7 +800,7 @@ class MystTranslator(SphinxTranslator):
             entry = node.attributes["entries"][0]
             entrytype, entryname, target, ignored, key = entry
             presyntax = "{" + "index" + "}`"
-            postsyntax = "<{}: {}>`".format(entrytype, entryname)
+            postsyntax = " <{}: {}>`".format(entrytype, entryname)
             # Save info for parsing at first Text node
             self.index["role_syntax"] = (presyntax, postsyntax)
 

--- a/tests/source/sphinx/index.rst
+++ b/tests/source/sphinx/index.rst
@@ -6,3 +6,4 @@ Sphinx Tests
    :caption: Contents:
 
    directives
+   roles

--- a/tests/source/sphinx/roles.rst
+++ b/tests/source/sphinx/roles.rst
@@ -1,0 +1,6 @@
+Roles
+=====
+
+:index:`Python <single: Python; common uses>` is a general-purpose language used in almost all application domains such as
+
+And another language :index:`Julia <single: Julia>` is also a scientific language

--- a/tests/test_mystparser.py
+++ b/tests/test_mystparser.py
@@ -99,7 +99,7 @@ def test_sphinx(
     get_sphinx_app_doctree(app, docname="directives", regress=True)
     get_sphinx_app_output(
         app,
-        files=["index.md", "directives.md"],
+        files=["index.md", "directives.md", "roles.md"],
         regress=True,
     )
 

--- a/tests/test_mystparser/test_docutils.myst
+++ b/tests/test_mystparser/test_docutils.myst
@@ -373,11 +373,11 @@ Test cases for role syntax
 
 Note: this will raise warnings as markup cannot be fully converted
 
-This is a standard {index}`paragraph<single: paragraph>`
+This is a standard {index}`paragraph <single: paragraph>`
 
-Is this the same {index}`with some text<single: paragraph>`
+Is this the same {index}`with some text <single: paragraph>`
 
-This is pair of entries {index}`index entries<pair: index; entry>`
+This is pair of entries {index}`index entries <pair: index; entry>`
 
 ## math
 

--- a/tests/test_mystparser/test_docutils.myst
+++ b/tests/test_mystparser/test_docutils.myst
@@ -373,11 +373,11 @@ Test cases for role syntax
 
 Note: this will raise warnings as markup cannot be fully converted
 
-This is a standard paragraph
+This is a standard {index}`paragraph<single: paragraph>`
 
-Is this the same with some text
+Is this the same {index}`with some text<single: paragraph>`
 
-This is pair of entries index entries
+This is pair of entries {index}`index entries<pair: index; entry>`
 
 ## math
 

--- a/tests/test_mystparser/test_sphinx.myst
+++ b/tests/test_mystparser/test_sphinx.myst
@@ -22,6 +22,7 @@ maxdepth: 2
 ---
 
 directives
+roles
 ```
 
 
@@ -77,4 +78,26 @@ HTML
 ```{only} latex
 LaTeX
 ```
+
+
+--------
+roles.md
+--------
+
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Roles
+
+{index}`Python<single: Python; common uses>` is a general-purpose language used in almost all application domains such as
+
+And another language {index}`Julia<single: Julia>` is also a scientific language
 

--- a/tests/test_mystparser/test_sphinx.myst
+++ b/tests/test_mystparser/test_sphinx.myst
@@ -97,7 +97,7 @@ kernelspec:
 
 # Roles
 
-{index}`Python<single: Python; common uses>` is a general-purpose language used in almost all application domains such as
+{index}`Python <single: Python; common uses>` is a general-purpose language used in almost all application domains such as
 
-And another language {index}`Julia<single: Julia>` is also a scientific language
+And another language {index}`Julia <single: Julia>` is also a scientific language
 


### PR DESCRIPTION
This PR adds support for the `:index:` role.

The following:

```rst
:index:`Julia <single: Julia>`
```

is added as

```md
{index}`Julia <single: Julia>`
```