### PR TITLE
[ENH] add support for citation references and bibliographies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
             "pytest>=3.6,<4",
             "pytest-cov",
             "pytest-regressions",
+            "sphinxcontrib-bibtex",
         ],
     },
 )

--- a/sphinx_tomyst/writers/sphinxcontrib_bibtex.py
+++ b/sphinx_tomyst/writers/sphinxcontrib_bibtex.py
@@ -1,0 +1,10 @@
+"""
+TODO: Node Visitor for bib_cache in translator
+to extract ":cited:, ":all:" options for the
+directive in myst file
+"""
+
+# from ast import NodeVisitor
+
+# class ExtractDirectiveSettings(NodeVisitor):
+#     pass

--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -117,6 +117,9 @@ class MystTranslator(SphinxTranslator):
         self.syntax = MystSyntax()
         self.images = []
         self.section_level = 0
+        # Support for sphinxcontrib-bibtex data
+        if "sphinxcontrib.bibtex" in self.builder.config.extensions:
+            self.bibtex_cache = self.builder.env.bibtex_cache
 
     # ----------#
     # -Document-#
@@ -249,6 +252,45 @@ class MystTranslator(SphinxTranslator):
     # https://docutils.sourceforge.io/docs/ref/doctree.html#author
     # https://docutils.sourceforge.io/docs/ref/doctree.html#authors
 
+    # sphinxcontrib-bibtex
+    # https://sphinxcontrib-bibtex.readthedocs.io/en/latest/index.html
+
+    def visit_bibliography(self, node):
+        """
+        TODO: add support for directive options :cited:, :notcited:, :all:
+        and :filter:
+        https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#filtering
+        """
+        docname = self.builder.current_docname
+        bib_id = node.attributes["ids"][0]
+        bib_cache = self.bibtex_cache.get_bibliography_cache(docname, bib_id)
+        srcdir = self.builder.srcdir
+        # Extract Directive Info
+        files = [x.replace(srcdir + "/", "") for x in bib_cache.bibfiles]
+        options = {}
+        if bib_cache.style != "alpha":
+            options["style"] = bib_cache.style
+        if bib_cache.encoding != "utf-8-sig":
+            options["encoding"] = bib_cache.encoding
+        if bib_cache.enumtype != "arabic":
+            options["enumtype"] = bib_cache.enumtype
+        if bib_cache.start != 1:
+            options["start"] = bib_cache.start
+        if bib_cache.labelprefix != "":
+            options["labelprefix"] = bib_cache.labelprefix
+        if bib_cache.keyprefix != "":
+            options["keyprefix"] = bib_cache.keyprefix
+        options = self.myst_options(options)
+        directive = self.syntax.visit_directive(
+            "bibliography", argument=" ".join(files), options=options
+        )
+        self.output.append(directive)
+        self.add_newline()
+
+    def depart_bibliography(self, node):
+        self.output.append(self.syntax.depart_directive())
+        self.add_newparagraph()
+
     # docutils.element.block_quote
     # class types: epigraph
     # https://docutils.sourceforge.io/docs/ref/doctree.html#block-quote
@@ -349,6 +391,14 @@ class MystTranslator(SphinxTranslator):
 
     # docutils.elements.citation_reference
     # https://docutils.sourceforge.io/docs/ref/doctree.html#citation-reference
+
+    def visit_citation_reference(self, node):
+        citation = node.astext()
+        self.output.append(self.syntax.visit_role("cite", citation))
+        raise nodes.SkipChildren
+
+    def depart_citation_reference(self, node):
+        self.output.append(self.syntax.depart_role())
 
     # docutils.elements.classifier
     # https://docutils.sourceforge.io/docs/ref/doctree.html#classifier
@@ -1134,6 +1184,7 @@ class MystTranslator(SphinxTranslator):
 
     # sphinx.pending_xref
     # https://www.sphinx-doc.org/en/master/extdev/nodes.html#sphinx.addnodes.pending_xref
+    # TODO: should visit_citation_references be implemented here?
 
     def visit_pending_xref(self, node):
         reftype = node.attributes["reftype"]
@@ -1203,7 +1254,7 @@ file will be included in the myst directive".format(
     # https://docutils.sourceforge.io/docs/ref/doctree.html#reference
 
     # TODO: rework references
-    # TODO: add syntax too MarkdownSyntax, MystSyntax
+    # TODO: add syntax to MarkdownSyntax, MystSyntax
 
     def visit_reference(self, node):
         self.reference = True

--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -1253,8 +1253,8 @@ file will be included in the myst directive".format(
     # docutils.elements.references
     # https://docutils.sourceforge.io/docs/ref/doctree.html#reference
 
-    # TODO: rework references
-    # TODO: add syntax to MarkdownSyntax, MystSyntax
+    # TODO: rework visit_reference, depart_reference
+    # TODO: update to include syntax from self.syntax
 
     def visit_reference(self, node):
         self.reference = True

--- a/tests/source/sphinxcontrib-bibtex/_static/testing.bib
+++ b/tests/source/sphinxcontrib-bibtex/_static/testing.bib
@@ -1,0 +1,15 @@
+###
+Testing Bibliography File used in conjuction with sphinxcontrib-bibtex package
+Note: Extended Information (like abstracts, doi, url's etc.) can be found in quant-econ-extendedinfo.bib file in _static/
+###
+
+@article{Bewley1977,
+    title={The permanent income hypothesis: A theoretical formulation},
+    author={Bewley, Truman},
+    journal={Journal of Economic Theory},
+    volume={16},
+    number={2},
+    pages={252--292},
+    year={1977},
+    publisher={Elsevier}
+}

--- a/tests/source/sphinxcontrib-bibtex/conf.py
+++ b/tests/source/sphinxcontrib-bibtex/conf.py
@@ -1,0 +1,3 @@
+extensions = ["sphinx_tomyst", "sphinxcontrib.bibtex"]
+exclude_patterns = ["_build"]
+tomyst_parser = "myst_parser"

--- a/tests/source/sphinxcontrib-bibtex/index.rst
+++ b/tests/source/sphinxcontrib-bibtex/index.rst
@@ -1,0 +1,11 @@
+``sphinxcontrib-bibtex`` Testing
+================================
+
+This is the index page
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   test
+   references

--- a/tests/source/sphinxcontrib-bibtex/references.rst
+++ b/tests/source/sphinxcontrib-bibtex/references.rst
@@ -1,0 +1,18 @@
+References
+==========
+
+.. bibliography:: _static/testing.bib
+
+.. only:: future
+
+   .. bibliography:: _static/testing.bib
+      :cited:
+
+   .. bibliography:: _static/testing.bib
+      :notcited:
+
+.. bibliography:: _static/testing.bib
+   :style: unsrt
+
+.. bibliography:: _static/testing.bib
+   :encoding: latin

--- a/tests/source/sphinxcontrib-bibtex/test.rst
+++ b/tests/source/sphinxcontrib-bibtex/test.rst
@@ -1,0 +1,5 @@
+Testing ``sphinxcontrib-bibtex``
+================================
+
+In this lecture, we describe the structure of a class of models
+that build on work by Truman Bewley :cite:`Bewley1977`.

--- a/tests/test_sphinxcontrib_bibtex.py
+++ b/tests/test_sphinxcontrib_bibtex.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+
+SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "source"))
+
+
+@pytest.mark.sphinx(
+    buildername="myst",
+    srcdir=os.path.join(SOURCE_DIR, "sphinxcontrib-bibtex"),
+    freshenv=True,
+)
+def test_sphinxcontrib_bibtex(
+    app,
+    status,
+    warning,
+    get_sphinx_app_doctree,
+    get_sphinx_app_output,
+    remove_sphinx_builds,
+):
+    """basic test."""
+    app.build()
+
+    assert "build succeeded" in status.getvalue()  # Build succeeded
+
+    # Note: pytest needs to run twice to initialise fixtures
+
+    get_sphinx_app_doctree(app, docname="test", regress=True)
+    get_sphinx_app_output(
+        app, files=["index.md", "test.md", "references.md"], regress=True
+    )

--- a/tests/test_sphinxcontrib_bibtex/test_sphinxcontrib_bibtex.myst
+++ b/tests/test_sphinxcontrib_bibtex/test_sphinxcontrib_bibtex.myst
@@ -1,0 +1,87 @@
+--------
+index.md
+--------
+
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# `sphinxcontrib-bibtex` Testing
+
+This is the index page
+
+```{toctree}
+---
+caption: Contents:
+maxdepth: 2
+---
+
+test
+references
+```
+
+
+-------
+test.md
+-------
+
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Testing `sphinxcontrib-bibtex`
+
+In this lecture, we describe the structure of a class of models
+that build on work by Truman Bewley {cite}`Bewley1977`.
+
+
+-------------
+references.md
+-------------
+
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# References
+
+```{bibliography} _static/testing.bib
+```
+
+```{only} future
+```{bibliography} _static/testing.bib
+```
+
+```{bibliography} _static/testing.bib
+```
+```
+
+```{bibliography} _static/testing.bib
+:style: unsrt
+```
+
+```{bibliography} _static/testing.bib
+:encoding: latin
+```
+

--- a/tests/test_sphinxcontrib_bibtex/test_sphinxcontrib_bibtex.xml
+++ b/tests/test_sphinxcontrib_bibtex/test_sphinxcontrib_bibtex.xml
@@ -1,0 +1,13 @@
+<document source="test.rst">
+    <section ids="testing-sphinxcontrib-bibtex" names="testing\ sphinxcontrib-bibtex">
+        <title>
+            Testing 
+            <literal>
+                sphinxcontrib-bibtex
+        <paragraph>
+            In this lecture, we describe the structure of a class of models
+            that build on work by Truman Bewley 
+            <pending_xref classes="bibtex" ids="id1" refdomain="citation" reftarget="Bewley1977" reftype="ref" refwarn="True" support_smartquotes="False">
+                <inline>
+                    [Bewley1977]
+            .


### PR DESCRIPTION
This adds translator support for setting up `:cite:` and `.. bibliography::` directive supported by `sphinxcontrib-bibtex` to myst roles and directives. 

**Not Supported:**

The following items aren't passed through:

1. `:cited:`
2. `:all:`
3. `:notcited:`, and
4. `:filter:`

https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#filtering

as parsing the information from `bib_cache.filter_` hasn't been included in this PR which is contained in an `ast` structure. 

The `:cited:` option will therefore be the effective `default` for all translations. 