### PR TITLE
[block_quote] fix nested math in blockquote context

### DIFF
--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -1099,15 +1099,15 @@ class MystTranslator(SphinxTranslator):
         math_block = []
         if self.math_block["options"]:
             math_block.append(self.syntax.visit_directive("math") + "\n")
-            math_block.append(self.math_block["options"])
-            math_block.append("\n\n")
+            if self.block_quote["in"]:
+                math_block.append(self.math_block["options"] + "\n>\n")
+            else:
+                math_block.append(self.math_block["options"] + "\n\n")
         else:
             math_block.append(self.syntax.visit_math_block() + "\n")
         if self.block_quote["in"]:
             if self.output[-1] == "\n\n":
                 self.output[-1] = "\n>\n"
-            if math_block[-1] == "\n\n":
-                math_block[-1] = "\n>\n"
             math_block = ["> {}".format(x) for x in math_block]
         self.output += math_block
 

--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -167,6 +167,8 @@ class MystTranslator(SphinxTranslator):
             # Remove block quote syntax from nested inline math
             if self.block_quote["in"]:
                 text = text.lstrip("> ")
+        if self.math_block["in"]:
+            text = text.rstrip()
         if self.index["in"] and self.index["type"] == "role":
             presyntax, postsyntax = self.index["role_syntax"]
             text = presyntax + text + postsyntax

--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -156,15 +156,15 @@ class MystTranslator(SphinxTranslator):
                 text = last_syntax + text
             linemarker = self.syntax.visit_block_quote()
             if self.block_quote["depart_math"]:
-                # No block_quote syntax for after nested math is added
+                # No block_quote syntax after nested inline math is added
                 self.block_quote["depart_math"] = False
             else:
                 text = linemarker + text
             text = text.replace("\n", "\n{}".format(linemarker))
         if self.caption:
             raise nodes.SkipNode
-        if self.math or self.math_block["in"]:
-            # Remove block quote syntax from nested math
+        if self.math:
+            # Remove block quote syntax from nested inline math
             if self.block_quote["in"]:
                 text = text.lstrip("> ")
         if self.index["in"] and self.index["type"] == "role":
@@ -1096,14 +1096,20 @@ class MystTranslator(SphinxTranslator):
     def visit_math_block(self, node):
         self.math_block["in"] = True
         self.math_block["options"] = self.infer_math_block_attrs(node)
+        math_block = []
         if self.math_block["options"]:
-            self.output.append(self.syntax.visit_directive("math"))
-            self.add_newline()
-            self.output.append(self.math_block["options"])
-            self.add_newparagraph()
+            math_block.append(self.syntax.visit_directive("math") + "\n")
+            math_block.append(self.math_block["options"])
+            math_block.append("\n\n")
         else:
-            self.output.append(self.syntax.visit_math_block())
-            self.add_newline()
+            math_block.append(self.syntax.visit_math_block() + "\n")
+        if self.block_quote["in"]:
+            if self.output[-1] == "\n\n":
+                self.output[-1] = "\n>\n"
+            if math_block[-1] == "\n\n":
+                math_block[-1] = "\n>\n"
+            math_block = ["> {}".format(x) for x in math_block]
+        self.output += math_block
 
     def infer_math_block_attrs(self, node):
         options = []
@@ -1115,11 +1121,17 @@ class MystTranslator(SphinxTranslator):
         return "\n".join(options)
 
     def depart_math_block(self, node):
+        math_block = []
         if self.math_block["options"]:
-            self.output.append(self.syntax.depart_directive())
+            math_block.append(self.syntax.depart_directive())
         else:
-            self.output.append(self.syntax.depart_math_block())
-        self.add_newparagraph()
+            math_block.append(self.syntax.depart_math_block())
+        if self.block_quote["in"]:
+            math_block = ["> {}".format(x) for x in math_block]
+            math_block.append("\n>\n")
+        else:
+            math_block.append("\n\n")
+        self.output += math_block
         self.math_block["in"] = False
 
     # docutils.elements.paragraph

--- a/tests/source/docutils/elements.rst
+++ b/tests/source/docutils/elements.rst
@@ -40,6 +40,26 @@ Let's listen to Wald longer:
    we commit an error of the second kind if we accept :math:`H_0` when
    :math:`H_1` is true.
 
+and a block quote with math block
+
+   This is a block quote with nested equation
+
+   .. math::
+
+      f_x = 0
+
+   with some additional text after the equation
+
+and a block quote with math block and options
+
+   This is a block quote with nested equation
+
+   .. math::
+      :class: test
+
+      f_x = 0
+
+   with some additional text after the equation
 
 bullet_list
 -----------

--- a/tests/source/docutils/elements.rst
+++ b/tests/source/docutils/elements.rst
@@ -55,7 +55,7 @@ and a block quote with math block and options
    This is a block quote with nested equation
 
    .. math::
-      :class: test
+      :nowrap:
 
       f_x = 0
 

--- a/tests/source/docutils/elements.rst
+++ b/tests/source/docutils/elements.rst
@@ -29,6 +29,18 @@ This is the main document
    This is a block quote context
    with multiple lines
 
+A longer example with nested math
+
+Let's listen to Wald longer:
+
+   As a basis for choosing among critical regions the following
+   considerations have been advanced by Neyman and Pearson: In accepting
+   or rejecting :math:`H_0` we may commit errors of two kinds. We commit
+   an error of the first kind if we reject :math:`H_0` when it is true;
+   we commit an error of the second kind if we accept :math:`H_0` when
+   :math:`H_1` is true.
+
+
 bullet_list
 -----------
 

--- a/tests/test_mystparser/test_docutils.myst
+++ b/tests/test_mystparser/test_docutils.myst
@@ -71,6 +71,26 @@ Let's listen to Wald longer:
 > we commit an error of the second kind if we accept $H_0$ when
 > $H_1$ is true.
 
+and a block quote with math block
+
+> This is a block quote with nested equation
+>
+> $$
+> f_x = 0
+> $$
+>
+> with some additional text after the equation
+
+and a block quote with math block and options
+
+> This is a block quote with nested equation
+>
+> $$
+> f_x = 0
+> $$
+>
+> with some additional text after the equation
+
 ## bullet_list
 
 A simple bullet list

--- a/tests/test_mystparser/test_docutils.myst
+++ b/tests/test_mystparser/test_docutils.myst
@@ -316,8 +316,6 @@ This is an important admonition
 
 $$
 (a + b)^2 = a^2 + 2ab + b^2
-
-
 $$
 
 $$

--- a/tests/test_mystparser/test_docutils.myst
+++ b/tests/test_mystparser/test_docutils.myst
@@ -85,9 +85,11 @@ and a block quote with math block and options
 
 > This is a block quote with nested equation
 >
-> $$
+> ```{math}
+> :nowrap:
+>
 > f_x = 0
-> $$
+> ```
 >
 > with some additional text after the equation
 

--- a/tests/test_mystparser/test_docutils.myst
+++ b/tests/test_mystparser/test_docutils.myst
@@ -60,6 +60,17 @@ This is the main document
 > This is a block quote context
 > with multiple lines
 
+A longer example with nested math
+
+Let's listen to Wald longer:
+
+> As a basis for choosing among critical regions the following
+> considerations have been advanced by Neyman and Pearson: In accepting
+> or rejecting $H_0$ we may commit errors of two kinds. We commit
+> an error of the first kind if we reject $H_0$ when it is true;
+> we commit an error of the second kind if we accept $H_0$ when
+> $H_1$ is true.
+
 ## bullet_list
 
 A simple bullet list
@@ -283,6 +294,8 @@ This is an important admonition
 
 $$
 (a + b)^2 = a^2 + 2ab + b^2
+
+
 $$
 
 $$

--- a/tests/test_mystparser/test_docutils.xml
+++ b/tests/test_mystparser/test_docutils.xml
@@ -97,6 +97,24 @@
                     <math>
                         H_1
                      is true.
+            <paragraph>
+                and a block quote with math block
+            <block_quote>
+                <paragraph>
+                    This is a block quote with nested equation
+                <math_block docname="elements" label="True" nowrap="False" number="True" xml:space="preserve">
+                    f_x = 0
+                <paragraph>
+                    with some additional text after the equation
+            <paragraph>
+                and a block quote with math block and options
+            <block_quote>
+                <paragraph>
+                    This is a block quote with nested equation
+                <math_block classes="test" docname="elements" label="True" nowrap="False" number="True" xml:space="preserve">
+                    f_x = 0
+                <paragraph>
+                    with some additional text after the equation
         <section ids="bullet-list" names="bullet_list">
             <title>
                 bullet_list

--- a/tests/test_mystparser/test_docutils.xml
+++ b/tests/test_mystparser/test_docutils.xml
@@ -74,6 +74,29 @@
                 <paragraph>
                     This is a block quote context
                     with multiple lines
+            <paragraph>
+                A longer example with nested math
+            <paragraph>
+                Let’s listen to Wald longer:
+            <block_quote>
+                <paragraph>
+                    As a basis for choosing among critical regions the following
+                    considerations have been advanced by Neyman and Pearson: In accepting
+                    or rejecting 
+                    <math>
+                        H_0
+                     we may commit errors of two kinds. We commit
+                    an error of the first kind if we reject 
+                    <math>
+                        H_0
+                     when it is true;
+                    we commit an error of the second kind if we accept 
+                    <math>
+                        H_0
+                     when
+                    <math>
+                        H_1
+                     is true.
         <section ids="bullet-list" names="bullet_list">
             <title>
                 bullet_list

--- a/tests/test_mystparser/test_docutils.xml
+++ b/tests/test_mystparser/test_docutils.xml
@@ -111,7 +111,7 @@
             <block_quote>
                 <paragraph>
                     This is a block quote with nested equation
-                <math_block classes="test" docname="elements" label="True" nowrap="False" number="True" xml:space="preserve">
+                <math_block docname="elements" label="True" nowrap="True" number="True" xml:space="preserve">
                     f_x = 0
                 <paragraph>
                     with some additional text after the equation


### PR DESCRIPTION
This PR fixes nested math in `block_quotes`

It can now parse block quotes such as

```
Let's listen to Wald longer:

    As a basis for choosing among critical regions the following
    considerations have been advanced by Neyman and Pearson: In accepting
    or rejecting :math:`H_0` we may commit errors of two kinds. We commit
    an error of the first kind if we reject :math:`H_0` when it is true;
    we commit an error of the second kind if we accept :math:`H_0` when
    :math:`H_1` is true. 
```

without adding `>` syntax to internal math components.