### PR TITLE
[FIX] fix bug with equations and strip whitespace either side

### DIFF
--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -168,7 +168,7 @@ class MystTranslator(SphinxTranslator):
             if self.block_quote["in"]:
                 text = text.lstrip("> ")
         if self.math_block["in"]:
-            text = text.rstrip()
+            text = text.strip()
         if self.index["in"] and self.index["type"] == "role":
             presyntax, postsyntax = self.index["role_syntax"]
             text = presyntax + text + postsyntax


### PR DESCRIPTION
This fixes an introduced bug where whitespace from equations wasn't getting stripped on the `left`