### PR TITLE
[ENH] new implementation for block_quote via accumulator

### DIFF
--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -322,7 +322,7 @@ class MystTranslator(SphinxTranslator):
             if self.block_quote["collect"][-1] == "\n\n":
                 self.block_quote["collect"].pop()
             block = "".join(self.block_quote["collect"])
-            block = block.replace("\n", "\n{} ".format(linemarker))
+            block = block.replace("\n", "\n{}".format(linemarker))
             self.output.append(block)
             self.add_newparagraph()
             self.block_quote["collect"] = []

--- a/tests/test_mystparser/test_docutils.myst
+++ b/tests/test_mystparser/test_docutils.myst
@@ -74,23 +74,23 @@ Let's listen to Wald longer:
 and a block quote with math block
 
 > This is a block quote with nested equation
->
+> 
 > $$
 > f_x = 0
 > $$
->
+> 
 > with some additional text after the equation
 
 and a block quote with math block and options
 
 > This is a block quote with nested equation
->
+> 
 > ```{math}
 > :nowrap:
->
+> 
 > f_x = 0
 > ```
->
+> 
 > with some additional text after the equation
 
 ## bullet_list


### PR DESCRIPTION
This PR changes how `block_quotes` are parsed (in addition to fixing List and Table accumulators for various types such as `strong` and `emphasis` nodes). The translator now accumulates block_quote items and then adds `>` syntax in `depart_block_quote`