### PR TITLE
ENH: add support for literalinclude transfer

### DIFF
--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -1089,6 +1089,8 @@ class MystTranslator(SphinxTranslator):
             if tags:
                 options.append("tags: [" + ", ".join(tags) + "]")
         # Parse `literalinclude` options
+        # Note: Not all options are current supported
+        # https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html?highlight=literalinclude#directive-literalinclude
         if node.hasattr("source"):
             if node.hasattr("language"):
                 options.append("language: {}".format(node.attributes["language"]))

--- a/tests/source/sphinx/_static/test.py
+++ b/tests/source/sphinx/_static/test.py
@@ -1,0 +1,1 @@
+import numpy as np  # noqa: F401

--- a/tests/source/sphinx/_static/test.txt
+++ b/tests/source/sphinx/_static/test.txt
@@ -1,0 +1,4 @@
+Some Test Text on Line 1
+Some Line 2 Test Text
+
+And Line 4

--- a/tests/source/sphinx/directives.rst
+++ b/tests/source/sphinx/directives.rst
@@ -22,6 +22,18 @@ The index directives
    single: Julia
    :name: test2
 
+literalinclude
+--------------
+
+.. literalinclude:: _static/test.txt
+
+.. literalinclude:: _static/test.txt
+   :emphasize-lines: 2
+   :linenos:
+
+.. literalinclude:: _static/test.py
+   :language: python
+
 only
 ----
 

--- a/tests/test_mystparser/test_sphinx.myst
+++ b/tests/test_mystparser/test_sphinx.myst
@@ -67,6 +67,24 @@ single: Julia
 ```
 
 (test2)=
+## literalinclude
+
+```{literalinclude} _static/test.txt
+```
+
+```{literalinclude} _static/test.txt
+---
+linenos:
+emphasize-lines: 2
+---
+```
+
+```{literalinclude} _static/test.py
+---
+language: python
+---
+```
+
 ## only
 
 The only directive

--- a/tests/test_mystparser/test_sphinx.xml
+++ b/tests/test_mystparser/test_sphinx.xml
@@ -15,7 +15,22 @@
             <target ids="index-1">
             <index entries="('single',\ 'Python;\ Runtime',\ 'test2',\ '',\ None) ('single',\ 'Julia',\ 'test2',\ '',\ None)" inline="False">
             <target refid="test2">
-        <section ids="only test2" names="only test2">
+        <section ids="literalinclude test2" names="literalinclude test2">
+            <title>
+                literalinclude
+            <literal_block force="False" highlight_args="{'linenostart': 1}" source="test.txt" xml:space="preserve">
+                Some Test Text on Line 1
+                Some Line 2 Test Text
+                
+                And Line 4
+            <literal_block force="False" highlight_args="{'hl_lines': [2], 'linenostart': 1}" linenos="True" source="test.txt" xml:space="preserve">
+                Some Test Text on Line 1
+                Some Line 2 Test Text
+                
+                And Line 4
+            <literal_block force="False" highlight_args="{'linenostart': 1}" language="python" source="test.py" xml:space="preserve">
+                import numpy as np  # noqa: F401
+        <section ids="only" names="only">
             <title>
                 only
             <paragraph>


### PR DESCRIPTION
This PR adds support for the direct transfer of `.. literalinclude::` markup and skips adding the `content`

**Note:** not all of the options are currently supported

https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html?highlight=literalinclude#directive-literalinclude