### PR TITLE
ENH: add support for collapse class -> output_scroll tags in jupyter-book

### DIFF
--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -1097,6 +1097,8 @@ class MystTranslator(SphinxTranslator):
                 tags.append("raises-exception")
             if "hide-output" in node.attributes["classes"]:
                 tags.append("hide-output")
+            if "collapse" in node.attributes["classes"]:
+                tags.append("output_scroll")
             if tags:
                 options.append("tags: [" + ", ".join(tags) + "]")
         # Parse `literalinclude` options

--- a/tests/source/mystnb-code-blocks/test.rst
+++ b/tests/source/mystnb-code-blocks/test.rst
@@ -62,6 +62,12 @@ Test hide-output passthrough to code-cells
     F = ECDF(samples)
     F(0.5)  # Evaluate ecdf at x = 0.5
 
+.. code-block:: python3
+    :class: collapse
+
+    for i in range(40):
+      print(i)
+
 Combinations
 ~~~~~~~~~~~~
 

--- a/tests/test_mystnb/test_code_blocks.myst
+++ b/tests/test_mystnb/test_code_blocks.myst
@@ -105,6 +105,14 @@ F = ECDF(samples)
 F(0.5)  # Evaluate ecdf at x = 0.5
 ```
 
+```{code-cell} python3
+---
+tags: [output_scroll]
+---
+for i in range(40):
+  print(i)
+```
+
 ### Combinations
 
 ```{code-cell} python3

--- a/tests/test_mystnb/test_code_blocks.xml
+++ b/tests/test_mystnb/test_code_blocks.xml
@@ -42,6 +42,9 @@
                 samples = [uniform(0, 1) for i in range(10)]
                 F = ECDF(samples)
                 F(0.5)  # Evaluate ecdf at x = 0.5
+            <literal_block classes="collapse" force="False" highlight_args="{}" language="python3" xml:space="preserve">
+                for i in range(40):
+                  print(i)
             <section ids="combinations" names="combinations">
                 <title>
                     Combinations


### PR DESCRIPTION
This PR adds support for `:class: collapse` and passes through to myst using `tags: ["output_scroll"]`

https://jupyterbook.org/content/layout.html#scrolling-cell-outputs