### PR TITLE
ENH: update doc roles to use document title from the environment

### DIFF
--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -1328,8 +1328,12 @@ class MystTranslator(SphinxTranslator):
         linktext = node.astext()
         if reftype == "eq":
             content = "{}".format(target)
+        elif reftype == "doc":
+            docname = node["refdoc"]
+            linktext = self.builder.env.longtitles[docname].astext()
+            content = "{} <{}>".format(linktext, target)
         else:
-            # doc, ref style links
+            # ref
             content = "{} <{}>".format(linktext, target)
         syntax = self.syntax.visit_role(reftype, content)
         if self.List:


### PR DESCRIPTION
This PR updates the `{doc}` role to use the `document` title from the `environment`