### PR TITLE
Fix: Add document name when no {doc} text is provided

### DIFF
--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -1329,8 +1329,10 @@ class MystTranslator(SphinxTranslator):
         if reftype == "eq":
             content = "{}".format(target)
         elif reftype == "doc":
-            docname = node["refdoc"]
-            linktext = self.builder.env.longtitles[docname].astext()
+            targetname = node["reftarget"]
+            if linktext == targetname:
+                # Update linktext to be the title of the target document
+                linktext = self.builder.env.longtitles[targetname].astext()
             content = "{} <{}>".format(linktext, target)
         else:
             # ref

--- a/sphinx_tomyst/writers/translator.py
+++ b/sphinx_tomyst/writers/translator.py
@@ -1328,8 +1328,12 @@ class MystTranslator(SphinxTranslator):
         linktext = node.astext()
         if reftype == "eq":
             content = "{}".format(target)
+        elif reftype == "doc":
+            docname = node["refdoc"]
+            linktext = self.builder.env.longtitles[docname].astext()
+            content = "{} <{}>".format(linktext, target)
         else:
-            # doc, ref style links
+            # ref
             content = "{} <{}>".format(linktext, target)
         syntax = self.syntax.visit_role(reftype, content)
         if self.List:


### PR DESCRIPTION
This fixes a bug in #100 that was merged too early to add a document name when no text is specified in the `{doc}` role